### PR TITLE
Fix for Issue #4

### DIFF
--- a/src/main/scala/org/scalastuff/scalabeans/sig/ClassDeclExtractor.scala
+++ b/src/main/scala/org/scalastuff/scalabeans/sig/ClassDeclExtractor.scala
@@ -41,7 +41,7 @@ object ClassDeclExtractor {
   /**
    * Declarations are grouped by the class where they appear in the Scala signature.
    */
-  private[this] val declarationsCache = new MapMaker().weakKeys().makeMap[Class[_], Option[Seq[Mirror.EntityDecl]]]()
+  private[this] val declarationsCache = new MapMaker().softValues().makeMap[Class[_], Option[Seq[Mirror.EntityDecl]]]()
 
   def extract(clazz: Class[_]): Option[Seq[Mirror.EntityDecl]] = {
     val cached = declarationsCache.get(clazz)

--- a/src/main/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompiler.scala
+++ b/src/main/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompiler.scala
@@ -27,7 +27,7 @@ import Mirror._
  */
 object ScalaTypeCompiler {
 
-  private[this] val classInfoCache = new MapMaker().weakKeys().makeMap[ScalaType, Option[ClassInfo]]()
+  private[this] val classInfoCache = new MapMaker().softValues().makeMap[ScalaType, Option[ClassInfo]]()
 
   /**
    * Parses Scala signature to collect property return types.


### PR DESCRIPTION
Using softValues seems more appropriate. It will be purged when memory is needed, but not on every GC. It also breaks the Strong Value to Weak Key link that kept memory from being reclaimed. Finally, object equals instead of identity will result in fewer cache entries.
