### PR TITLE
Bug Fix getting Class Info from a class with a field from another class' inner class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.scalastuff</groupId>
 	<artifactId>scalabeans</artifactId>
 	<packaging>jar</packaging>
-	<version>0.3</version>
+	<version>0.4-SNAPSHOT</version>
 	<name>ScalaBeans</name>
 	<description>Reflection toolkit for Scala</description>
 	<url>http://scalastuff.org</url>

--- a/src/main/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompiler.scala
+++ b/src/main/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompiler.scala
@@ -153,6 +153,7 @@ class ScalaTypeCompiler(scalaType: ScalaType, classDecl: ClassDecl) {
     def getTypeDecl(t: Type): TypeDecl = t match {
       case tp: TypeProjection =>
         tp.parent match {
+          case ptp: TypeProjection => getTypeDecl(ptp)
           case st: SingletonType =>
             st.path match {
               case mp: MemberPath =>

--- a/src/test/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompilerTest.scala
+++ b/src/test/scala/org/scalastuff/scalabeans/sig/ScalaTypeCompilerTest.scala
@@ -1,0 +1,19 @@
+package org.scalastuff.scalabeans.sig
+
+import org.junit.Test
+
+/**
+ * For some reason these test helper classes have to be at the top level scope. The test did not fail if the classes
+ * were in the scope of the test class or test function.
+ */
+class OuterTestClass {
+  class InnerTestClass
+}
+class Container(val inner: OuterTestClass#InnerTestClass)
+
+class ScalaTypeCompilerTest {
+  @Test
+  def testInnerClassExtractable() {
+    ScalaTypeCompiler.classInfoOf[Container]
+  }
+}


### PR DESCRIPTION
I'm using jackson-module-scala which uses scalabeans under the covers. I want to serialize a class that looks like this:

``` scala
class Metrics {
  outer =>
  val numThingA = new Counter(...)
  val numThingB  = new Counter(...)
  val currThingC = new AtomicReference(...)
  // ... etc you get the point

  def newSnapshot = new Snapshot  
  case class Snapshot (
    numThingA: Long = outer.numThingA.count,
    numThingB: Long = outer.numThingB.count,
    currThingC: C = outer.currThingC.get
  )
}
```

In the end I stick the snapshot into a case class:

``` scala
case class DataResponse(..., metrics: Metrics#Snapshot)
```

But it fails to serialize the snapshot with this exception:

``` java
scala.MatchError: org.scalastuff.scalabeans.sig.OuterTestClass (of class org.scalastuff.scalabeans.sig.ClassDeclExtractor$$anonfun$13$$anon$10)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler.getTypeDecl$1(ScalaTypeCompiler.scala:155)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler.resolveScalaType(ScalaTypeCompiler.scala:167)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$3.apply(ScalaTypeCompiler.scala:146)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$3.apply(ScalaTypeCompiler.scala:145)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:233)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:233)
    at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:60)
    at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:47)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:233)
    at scala.collection.mutable.ArrayBuffer.map(ArrayBuffer.scala:47)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler.compile(ScalaTypeCompiler.scala:145)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$1$$anonfun$apply$2.apply(ScalaTypeCompiler.scala:51)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$1$$anonfun$apply$2.apply(ScalaTypeCompiler.scala:48)
    at scala.Option$WithFilter.map(Option.scala:174)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$1.apply(ScalaTypeCompiler.scala:48)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$$anonfun$1.apply(ScalaTypeCompiler.scala:47)
    at scala.Option.flatMap(Option.scala:146)
    at org.scalastuff.scalabeans.sig.ScalaTypeCompiler$.classInfoOf(ScalaTypeCompiler.scala:47)
...
```

So, here's a fix... and it works. Test fails beforehand but required the helper classes to be at the top level.
